### PR TITLE
Add PyPi CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,19 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: wheelhouse/*.whl
+
+  publish-pypi:
+    name: Publish PyPi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [run-bindgen]
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+    - name: Publish wheels
+      uses: pypa/gh-action-pypi-publish@v1.5.1
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -17,9 +17,9 @@ git clone --depth 1 https://github.com/wingdeans/rizin.git -b header-types
 pushd rizin
 
 if [[ "$OSTYPE" =~ msys* ]]; then
-    meson setup --prefix='c:/rizin' --vsenv build
+    meson setup --buildtype=release --prefix='c:/rizin' --vsenv build
 else
-    meson setup --libdir=lib build
+    meson setup --buildtype=release --libdir=lib build
 fi
 
 meson install -C build

--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,7 @@ if target_swig
       '-outdir', '@OUTDIR@', '@INPUT@'
     ],
     install: true,
-    install_dir: [false, py.get_install_dir()]
+    install_dir: [py.get_install_dir(), false]
   )
   swig_py = swig_output[0]
   swig_wrap = swig_output[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ archs = ["AMD64"]
 name = "rz-bindings"
 version = "0.0.1"
 requires-python = ">=3.8"
+readme = "README.md"


### PR DESCRIPTION
* Add PyPi upload CI job
* Install generated rizin.py script instead of rizin.cxx (bug)
* Use Rizin release build for cibuildwheel

CI Job needs PyPi token, as Github secret `PYPI_TOKEN`.
This PR only sets up the CI, but there is no need to release right away.
I want to add tests and integrate delvewheel for Windows builds before a 0.0.1 release.