### PR TITLE
Activate pybuffer typemaps by default

### DIFF
--- a/src/binding_typemap.py
+++ b/src/binding_typemap.py
@@ -55,17 +55,3 @@ class Typemap:
             f"Function {func.cfunc.cursor.spelling} did not match typemap `{self.args}`. "
             f"Contents were: {args}"
         )
-
-
-buffer_len_typemap = Typemap(
-    "buffer_len",
-    [TypemapArg("unsigned char *", "buf"), TypemapArg("unsigned long long", "len")],
-)
-
-const_buffer_len_typemap = Typemap(
-    "const_buffer_len",
-    [
-        TypemapArg("const unsigned char *", "buf"),
-        TypemapArg("unsigned long long", "len"),
-    ],
-)

--- a/src/bindings.py
+++ b/src/bindings.py
@@ -12,7 +12,6 @@ from binding_class import Class
 from binding_director import Director
 from binding_enum import Enum, MacroEnum
 from binding_generic import Generic
-from binding_typemap import buffer_len_typemap, const_buffer_len_typemap
 
 HeaderFunc = Callable[[Header], None]
 threaded_headers: OrderedDict[str, HeaderFunc] = OrderedDict()
@@ -214,27 +213,7 @@ def bind_buf(buf_h: Header) -> None:
     RzBuf
     """
     rz_buf = Class(buf_h, typedef="RzBuffer")
-
-    # const ut8 *buffer, ut64 len
-    for name in [
-        "append_bytes",
-        "prepend_bytes",
-        "set_bytes",
-        "insert_bytes",
-        "write",
-        "write_at",
-    ]:
-        rz_buf.add_method(
-            f"rz_buf_{name}",
-            rename=name,
-            typemaps=[const_buffer_len_typemap],
-        )
-
-    # ut8 *buffer, ut64 len
-    rz_buf.add_method("rz_buf_read", rename="read", typemaps=[buffer_len_typemap])
-    rz_buf.add_method("rz_buf_read_at", rename="read_at", typemaps=[buffer_len_typemap])
-
-    rz_buf.add_method("rz_buf_seek", rename="seek")
+    rz_buf.add_prefixed_methods("rz_buf_")
 
     MacroEnum(buf_h, "RZ_BUF_SET", "RZ_BUF_CUR", "RZ_BUF_END")
 

--- a/src/snippets_swig/prologue.i
+++ b/src/snippets_swig/prologue.i
@@ -21,22 +21,10 @@ void rizin_try_warn_deprecate(const char *name, const char *c_name) {
 
 // Buffer typemaps
 %include <pybuffer.i>
-
-%define %buffer_len_activate(TYPE, SIZE)
-%pybuffer_mutable_binary(TYPE, SIZE);
-%enddef
-
-%define %const_buffer_len_activate(TYPE, SIZE)
-%pybuffer_binary(TYPE, SIZE);
-%enddef
-
-%define %buffer_len_deactivate(TYPE, SIZE)
-%typemap(in) (TYPE, SIZE);
-%enddef
-
-%define %const_buffer_len_deactivate(TYPE, SIZE)
-%typemap(in) (TYPE, SIZE);
-%enddef
+%pybuffer_mutable_binary(unsigned char *buf, unsigned long long len);
+%pybuffer_binary(const unsigned char *buf, unsigned long long len);
+%pybuffer_mutable_binary(unsigned char *buf, int len);
+%pybuffer_binary(const unsigned char *buf, int len);
 
 // CArrays
 %include <carrays.i>


### PR DESCRIPTION
Only matches on functions with `ut8 *buf, ut64 len` and `ut8 *buf, int len` arguments.

This fails to match for functions like: `int rz_core_print_disasm_instructions_with_buf(RzCore *core, ut64 address, ut8 *buf, int nb_bytes, int nb_opcodes);` due to differing names for the buffer length argument.