### PR TITLE
Remove typelink remnants

### DIFF
--- a/src/bindings.py
+++ b/src/bindings.py
@@ -153,7 +153,7 @@ def bind_analysis(analysis_h: Header) -> None:
         analysis_h,
         typedef="RzAnalysis",
         ignore_fields={"leaddrs"},
-        rename_fields={"type_links": "_type_links"},
+        rename_fields={},
     )
 
     rz_analysis_function = Class(analysis_h, typedef="RzAnalysisFunction")


### PR DESCRIPTION
Typelinks were removed for the Rizin 0.6.0 release

Closes https://github.com/rizinorg/rz-bindgen/issues/31 (the `priv_232dbg` one is Windows specific, so it's fine to have this warning on Linux)