### PR TITLE
Fix build due to `ht_*.h` move and non-use of llvm-config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ target_sphinx = targets.contains('sphinx')
 doxygen_path = get_option('doxygen_path')
 
 if clang_path == ''
-  llvm_config = find_program('llvm-config', required: false)
+  llvm_config = find_program('llvm-config', 'llvm-config-7', required: false)
   if llvm_config.found()
     clang_path = run_command(llvm_config, '--libdir', check: true).stdout().strip()
   elif build_machine.system() == 'darwin'

--- a/meson.build
+++ b/meson.build
@@ -19,9 +19,9 @@ target_sphinx = targets.contains('sphinx')
 doxygen_path = get_option('doxygen_path')
 
 if clang_path == ''
-  llvm = dependency('llvm', required: false)
-  if llvm.found()
-    clang_path = llvm.get_variable(cmake: 'LLVM_LIBRARY_DIRS', configtool: 'libdir', default_value: 'none')
+  llvm_config = find_program('llvm-config', required: false)
+  if llvm_config.found()
+    clang_path = run_command(llvm_config, '--libdir', check: true).stdout().strip()
   elif build_machine.system() == 'darwin'
     clang_path = '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/'
   elif build_machine.system() == 'windows'

--- a/src/bindings.py
+++ b/src/bindings.py
@@ -425,7 +425,7 @@ def bind_ls(ls_h: Header) -> None:
     Class(ls_h, typedef="SdbList")
 
 
-@threaded_header("sdb/ht_pp.h")
+@threaded_header("rz_util/ht_pp.h")
 def bind_ht_pp(ht_pp_h: Header) -> None:
     """
     ht_pp
@@ -433,7 +433,7 @@ def bind_ht_pp(ht_pp_h: Header) -> None:
     Class(ht_pp_h, typedef="HtPP")
 
 
-@threaded_header("sdb/ht_pu.h")
+@threaded_header("rz_util/ht_pu.h")
 def bind_ht_pu(ht_pu_h: Header) -> None:
     """
     ht_pu
@@ -441,7 +441,7 @@ def bind_ht_pu(ht_pu_h: Header) -> None:
     Class(ht_pu_h, typedef="HtPU")
 
 
-@threaded_header("sdb/ht_up.h")
+@threaded_header("rz_util/ht_up.h")
 def bind_ht_up(ht_up_h: Header) -> None:
     """
     ht_up
@@ -449,7 +449,7 @@ def bind_ht_up(ht_up_h: Header) -> None:
     Class(ht_up_h, typedef="HtUP")
 
 
-@threaded_header("sdb/ht_uu.h")
+@threaded_header("rz_util/ht_uu.h")
 def bind_ht_uu(ht_uu_h: Header) -> None:
     """
     ht_uu

--- a/src/cparser_header.py
+++ b/src/cparser_header.py
@@ -98,12 +98,6 @@ class HeaderBuilder:
 
         assert rizin_include_path
         filename = os.path.abspath(os.path.join(rizin_include_path, *name_segments))
-
-        # Fix sdb path if using source librz/include
-        if name_segments[0] == "sdb" and not os.path.exists(filename):
-            name_segments = ["..", "util", "sdb", "src"] + name_segments[1:]
-            filename = os.path.abspath(os.path.join(rizin_include_path, *name_segments))
-
         assert os.path.exists(filename)
         self.filename = filename
 


### PR DESCRIPTION
This pr should fix the broken build due to

![ht-move-failure](https://github.com/rizinorg/rz-bindgen/assets/12002672/694af665-9fa4-47a2-ab3b-bdc918d966d9)
(https://github.com/rizinorg/rizin/actions/runs/6613041973/job/17960372892#step:7:46)

and #35, and should close #35, by changing some paths and using `llvm-config` (as per README.md) instead of whatever it's using right now.