### PR TITLE
Disable pylint `too-many-arguments` warning

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,8 +1,9 @@
 [MESSAGES CONTROL]
 disable=too-many-instance-attributes,
-        too-few-public-methods,
+	too-few-public-methods,
 	too-many-branches,
 	too-many-return-statements,
 	too-many-locals,
+	too-many-arguments,
 	broad-exception-raised,
 	fixme


### PR DESCRIPTION
As per https://github.com/rizinorg/rz-bindgen/pull/37#issuecomment-1780288944, this pr disables pylint's `too-many-arguments` warning.