### PR TITLE
Fix CI images to `ubuntu-22.04` and `macos-12`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-22.04, windows-2019, macos-12]
 
     steps:
     - name: Checkout rz-bindgen

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: lint
 on: push
 jobs:
   licenses:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout rz-bindgen
       uses: actions/checkout@v3
@@ -10,7 +10,7 @@ jobs:
       uses: fsfe/reuse-action@v1
 
   python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout rz-bindgen
       uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       if: ${{ always() }}
 
   codeql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   extract-rizin-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       rizin_version: ${{ steps.extract_version.outputs.result }}
     steps:
@@ -21,7 +21,7 @@ jobs:
       rizin_ref: ${{ needs.extract-rizin-version.outputs.rizin_version }}
 
   publish-pypi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build]
     steps:
     - name: Download artifacts


### PR DESCRIPTION
Following the Rizin CI, this pr fixes rz-bindgen's CI images to `ubuntu-22.04` and `macos-12` so that builds are not affected by unexpected image version changes.