### PR TITLE
Fix Meson to 1.2.3

### DIFF
--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -4,7 +4,7 @@
 set -ex
 
 # Install deps
-pip3 install meson ninja meson-python build
+pip3 install meson==1.2.3 ninja meson-python build
 
 if command -v apt; then
     set +e


### PR DESCRIPTION
This pr fixes Meson to 1.2.3 due to libzip build problems reported in rizinorg/rizin#3990.