### PR TITLE
Revert "Fix Meson to 1.2.3"

### DIFF
--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -4,7 +4,7 @@
 set -ex
 
 # Install deps
-pip3 install meson==1.2.3 ninja meson-python build
+pip3 install meson ninja meson-python build
 
 if command -v apt; then
     set +e


### PR DESCRIPTION
Since rizinorg/rizin#3995 has been merged, there is no longer any need to fix Meson to 1.2.3.