### PR TITLE
Use default LLVM in Ubuntu build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
         name: wheels
         path: wheelhouse/*.whl
 
-  ubuntu-llvm-15:
+  ubuntu-default-llvm:
     runs-on: ubuntu-22.04
     env:
-      CC: clang-15
-      CXX: clang++-15
+      CC: clang
+      CXX: clang++
 
     steps:
     - name: Checkout rz-bindgen
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt-get --assume-yes install cmake swig pkg-config clang-15 libclang-15-dev llvm-15 wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja
+        sudo apt-get --assume-yes install cmake swig pkg-config clang libclang-dev llvm wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja
 
     - name: Install rizin
       run: |

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ target_sphinx = targets.contains('sphinx')
 doxygen_path = get_option('doxygen_path')
 
 if clang_path == ''
-  llvm_config = find_program('llvm-config-15', 'llvm-config', 'llvm-config-7', required: false)
+  llvm_config = find_program('llvm-config', 'llvm-config-7', required: false)
   if llvm_config.found()
     clang_path = run_command(llvm_config, '--libdir', check: true).stdout().strip()
   elif build_machine.system() == 'darwin'
@@ -46,7 +46,7 @@ if rizin_include_path == ''
 endif
 
 if clang_args == ''
-  clang = find_program('clang-15', 'clang', 'clang-7', required: false)
+  clang = find_program('clang', 'clang-7', required: false)
   if clang.found()
     clang_args += ' -resource-dir='
     clang_args += '"' + run_command(clang, '-print-resource-dir', check: true).stdout().strip() + '"'


### PR DESCRIPTION
This pr chooses the simpler option of using the default LLVM in this CI's Ubuntu build (rather than removing the `clang-15` and `llvm-15` packages from the Rizin CI build). This should fix #45 -- rebuilding https://github.com/rizinorg/rizin/actions/runs/7073760702/job/19254258618?pr=4012 should confirm the fix.