### PR TITLE
Use `fetch-depth` of 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
       with:
         repository: rizinorg/rizin
         path: rizin
-        fetch-depth: 2
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
The default value of `fetch-depth` is 1 rather than 0 or all (oops), and since there's no reason to change `fetch-depth` here from its default setting, this pr removes it.