### PR TITLE
Bump minimum meson version to 0.62.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For usage information, see [the documentation](doc/README.md).
 ## Building python plugin
 Requirements:
 - rizin > 0.4.1 (needs commit [59b38e6](https://github.com/rizinorg/rizin/commit/59b38e6efaf00b9b9869e0ec5baba4f1b9605f37))
-- meson
+- meson >= 0.62.2
 - ninja
 - python >= 3.7
 - libclang

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('rz-bindgen', 'c', 'cpp',
   version: '0.6.0',
   license: 'LGPL3',
-  meson_version: '>=0.53.0',
+  meson_version: '>=0.62.2',
   default_options: ['python.install_env=auto'])
 
 pymod = import('python')


### PR DESCRIPTION
This pr bumps the minimum meson version to 0.62.2 because:
1. `python.install_env` is first supported in meson 0.62.0.
2. Meson 0.62.2 has https://github.com/mesonbuild/meson/commit/cc4aed4739e9ec5c7933658a2bb80a95eca3efd4, which can prevent an error at https://github.com/rizinorg/rz-bindgen/blob/012c7073aef9d97fda1697812c3b9d2f74bf0397/meson.build#L44