### PR TITLE
Support user install of swig python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For usage information, see [the documentation](doc/README.md).
 ## Building python plugin
 Requirements:
 - rizin > 0.4.1 (needs commit [59b38e6](https://github.com/rizinorg/rizin/commit/59b38e6efaf00b9b9869e0ec5baba4f1b9605f37))
-- meson >= 0.62.2
+- meson >= 1.1.0
 - ninja
-- python >= 3.7
+- python >= 3.10
 - libclang
 - SWIG
 

--- a/meson.build
+++ b/meson.build
@@ -117,7 +117,7 @@ if target_swig
       '-python', '-c++',
       '-outdir', '@OUTDIR@', '@INPUT@'
     ],
-    install: true,
+    install: host_machine.system() == 'windows',
     install_dir: [py.get_install_dir(), false]
   )
   swig_py = swig_output[0]
@@ -127,15 +127,18 @@ if target_swig
     rz_core = dependency('rz_core')
   endif
 
-  py.extension_module(
+  ext_mod = py.extension_module(
     '_rizin',
     swig_wrap,
     dependencies: [
       py.dependency(),
       rz_core,
     ],
-    install: true,
+    install: host_machine.system() == 'windows',
   )
+  if host_machine.system() != 'windows'
+    meson.add_install_script('py_install.py', swig_py.full_path(), ext_mod.full_path())
+  endif
 endif
 
 if target_sphinx
@@ -155,4 +158,3 @@ endif
 if get_option('plugin').enabled()
   subdir('plugin')
 endif
-

--- a/py_install.py
+++ b/py_install.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import sys
+import sysconfig
+
+def install_files(scheme):
+    for file in sys.argv[1:]:
+        if file.endswith(".py"):
+            dest_type = 'purelib'
+        elif file.endswith(".so"):
+            dest_type = 'platlib'
+        install_dir = sysconfig.get_path(dest_type, scheme)
+        shutil.copy(file, install_dir)
+        print(f"Installing {os.path.basename(file)} to {install_dir}")
+
+try:
+    install_files(sysconfig.get_default_scheme())
+except PermissionError:
+    print("Installing to user site-packages since normal site-packages is not writeable")
+    install_files(f"{os.name}_user")

--- a/py_install.py
+++ b/py_install.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+"""
+SPDX-FileCopyrightText: 2024 kazarmy <kazarmy@gmail.com>
+SPDX-License-Identifier: LGPL-3.0-only
+"""
 
 import os
 import shutil


### PR DESCRIPTION
This pr supports installation of the swig python module to the user site-packages directory, if installation cannot be done to the system site-packages directory. The reasons for supporting this is twofold:

1. Allows installation without `sudo`.
2. Prevents [this error](https://github.com/mesonbuild/meson/issues/11751#issue-1689744609) from popping up.

Minimum Python version has been bumped to 3.10 due to [`sysconfig.get_default_scheme()`](https://docs.python.org/3.10/library/sysconfig.html#sysconfig.get_default_scheme), while minimum Meson version has been bumped to 1.1.0 due to [this fix](https://github.com/mesonbuild/meson/commit/ce62190b17e136c5b6810d3360b2cd71d0756920).