### PR TITLE
Fix build fail due to missing rz_analysis_version

### DIFF
--- a/src/bindings.py
+++ b/src/bindings.py
@@ -147,8 +147,6 @@ def bind_analysis(analysis_h: Header) -> None:
     """
     RzAnalysis
     """
-    analysis_h.ignore("rz_analysis_version")
-
     rz_analysis = Class(
         analysis_h,
         typedef="RzAnalysis",


### PR DESCRIPTION
This pr just fixes the build failure due to the removal of `rz_analysis_version` in rizinorg/rizin@d47ceedbd354fbc007f01e40ab8326730359c518.