### PR TITLE
Set CIBW_BUILD_VERBOSITY to 1 for pypa wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
 
     - name: Build rz-bindgen
       uses: pypa/cibuildwheel@v2.8.0
+      env:
+        CIBW_BUILD_VERBOSITY: 1
 
     - name: Upload sdist
       uses: actions/upload-artifact@v3

--- a/meson.build
+++ b/meson.build
@@ -117,7 +117,7 @@ if target_swig
       '-python', '-c++',
       '-outdir', '@OUTDIR@', '@INPUT@'
     ],
-    install: host_machine.system() == 'windows',
+    install: true, # host_machine.system() == 'windows',
     install_dir: [py.get_install_dir(), false]
   )
   swig_py = swig_output[0]
@@ -134,7 +134,7 @@ if target_swig
       py.dependency(),
       rz_core,
     ],
-    install: host_machine.system() == 'windows',
+    install: true, # host_machine.system() == 'windows',
   )
   if host_machine.system() != 'windows'
     meson.add_install_script('py_install.py', swig_py.full_path(), ext_mod.full_path())


### PR DESCRIPTION
This pr should result in better visibility as to the reasons why a pypa wheel build has gone wrong.