### PR TITLE
Patch meson.build for wheel build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Patch meson.build for wheel build
       if: matrix.os != 'windows-2019'
-      run: sed -i 's/^\([[:blank:]]*install:\) host_machine.*$/\1 true,/' meson.build
+      run: sed -i.bak 's/^\([[:blank:]]*install:\) host_machine.*$/\1 true,/' meson.build
 
     - name: Build rz-bindgen
       uses: pypa/cibuildwheel@v2.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         path: rizin
         ref: ${{ inputs.rizin_ref }}
 
+    - name: Patch meson.build for wheel build
+      if: matrix.os != 'windows-2019'
+      run: sed -i 's/^\([[:blank:]]*install:\) host_machine.*$/\1 true,/' meson.build
+
     - name: Build rz-bindgen
       uses: pypa/cibuildwheel@v2.8.0
 


### PR DESCRIPTION
Since [Meson doesn't allow direct reading of environment variables](https://github.com/mesonbuild/meson/issues/9#issuecomment-543780613), this pr uses `sed` to patch `meson.build` for the pypa wheel builds. The patch result should be:

```patch
diff --git a/meson.build b/meson.build
index 3d6214c..6beb707 100644
--- a/meson.build
+++ b/meson.build
@@ -117,7 +117,7 @@ if target_swig
       '-python', '-c++',
       '-outdir', '@OUTDIR@', '@INPUT@'
     ],
-    install: host_machine.system() == 'windows',
+    install: true,
     install_dir: [py.get_install_dir(), false]
   )
   swig_py = swig_output[0]
@@ -134,7 +134,7 @@ if target_swig
       py.dependency(),
       rz_core,
     ],
-    install: host_machine.system() == 'windows',
+    install: true,
   )
   if host_machine.system() != 'windows'
     meson.add_install_script('py_install.py', swig_py.full_path(), ext_mod.full_path())
```

----

The `sed` suffix trick is from [here](https://unix.stackexchange.com/questions/663369/invalid-command-code-using-sed-to-replace-characters-inline), [here](https://unix.stackexchange.com/questions/92895/how-can-i-achieve-portability-with-sed-i-in-place-editing) and [here](https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux).