### PR TITLE
Fix SWIG snippet example

### DIFF
--- a/src/snippets_swig/register_swig_command.cpp
+++ b/src/snippets_swig/register_swig_command.cpp
@@ -13,7 +13,7 @@ void register_swig_command(const char *str, CmdDirector *director,
         } else {
                 char *dup = strdup(str);
                 dup[len - 1] = '\0';
-                parent = (RzCmdDesc *)ht_pp_find($self->ht_cmds, dup, NULL);
+                parent = (RzCmdDesc *)ht_sp_find($self->ht_cmds, dup, NULL);
                 free(dup);
         }
 
@@ -21,7 +21,7 @@ void register_swig_command(const char *str, CmdDirector *director,
                 throw "Could not get parent RzCmdDesc";
         }
 
-        RzCmdDesc *prev = (RzCmdDesc *)ht_pp_find($self->ht_cmds, str, NULL);
+        RzCmdDesc *prev = (RzCmdDesc *)ht_sp_find($self->ht_cmds, str, NULL);
         std::string cmd(str);
         if (prev) { // Update existing RzCmdDesc
                 auto it = SWIGCmds.find(cmd);


### PR DESCRIPTION
Fix the following error:
```
c++ -I_rizin.cpython-310-x86_64-linux-gnu.so.p -I. -I.. -I/usr/include/python3.10 -I/usr/include/x86_64-linux-gnu/python3.10 -I/usr/include/librz -I/usr/include/librz/sdb -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -fPIC -MD -MQ _rizin.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._rizin_wrap.cxx.o -MF _rizin.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._rizin_wrap.cxx.o.d -o _rizin.cpython-310-x86_64-linux-gnu.so.p/meson-generated_.._rizin_wrap.cxx.o -c rizin_wrap.cxx
rizin_wrap.cxx: In function ‘void rz_cmd_t_register_swig_command__SWIG_0(rz_cmd_t*, const char*, CmdDirector*, RzCmdDescHelp*, RzCmdDescHelp*)’:
rizin_wrap.cxx:8388:56: error: cannot convert ‘HtSP*’ {aka ‘ht_sp_t*’} to ‘HtPP*’ {aka ‘ht_pp_t*’}
 8388 |                 parent = (RzCmdDesc *)ht_pp_find(self->ht_cmds, dup, NULL);
      |                                                  ~~~~~~^~~~~~~
      |                                                        |
      |                                                        HtSP* {aka ht_sp_t*}
In file included from /usr/include/librz/rz_util/ht_pp.h:18,
                 from /usr/include/librz/rz_list.h:5,
                 from rizin_wrap.cxx:3769:
/usr/include/librz/rz_util/ht_inc.h:171:53: note:   initializing argument 1 of ‘void* ht_pp_find(HtPP*, const void*, bool*)’
  171 | RZ_API VALUE_TYPE Ht_(find)(RZ_NONNULL HtName_(Ht) *ht, const KEY_TYPE key, RZ_NULLABLE bool *found);
      |                                                     ^
rizin_wrap.cxx:8396:57: error: cannot convert ‘HtSP*’ {aka ‘ht_sp_t*’} to ‘HtPP*’ {aka ‘ht_pp_t*’}
 8396 |         RzCmdDesc *prev = (RzCmdDesc *)ht_pp_find(self->ht_cmds, str, NULL);
      |                                                   ~~~~~~^~~~~~~
      |                                                         |
      |                                                         HtSP* {aka ht_sp_t*}
In file included from /usr/include/librz/rz_util/ht_pp.h:18,
                 from /usr/include/librz/rz_list.h:5,
                 from rizin_wrap.cxx:3769:
/usr/include/librz/rz_util/ht_inc.h:171:53: note:   initializing argument 1 of ‘void* ht_pp_find(HtPP*, const void*, bool*)’
  171 | RZ_API VALUE_TYPE Ht_(find)(RZ_NONNULL HtName_(Ht) *ht, const KEY_TYPE key, RZ_NULLABLE bool *found);
      |                                                     ^
rizin_wrap.cxx: In function ‘PyObject* _wrap_RzBuffer_fwd_scan(PyObject*, PyObject*)’:
rizin_wrap.cxx:75757:3: warning: NULL used in arithmetic [-Wpointer-arith]
75757 |   SWIG_contract_assert((result!=NULL), "Contract violation: require: (result!=NULL)");
      |   ^~~~~~~~~~~~~~~~~~~~
```