### PR TITLE
Use `manylinux2014` base image instead

### DIFF
--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -20,7 +20,7 @@ if command -v apt; then
 elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
-    yum -y install centos-release-scl llvm-toolset-7.0
+    yum -y install centos-release-scl llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
     source scl_source enable llvm-toolset-7.0 || true
     ln -s `which clang` /usr/local/bin/clang
     ln -s `which clang-7` /usr/local/bin/clang-7

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -20,8 +20,7 @@ if command -v apt; then
 elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
-    yum install centos-release-scl
-    yum install llvm-toolset-7.0
+    yum -y install centos-release-scl llvm-toolset-7.0
     scl enable llvm-toolset-7.0 bash
 fi
 

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -21,7 +21,7 @@ elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
     yum -y install centos-release-scl llvm-toolset-7.0
-    scl enable llvm-toolset-7.0 bash
+    source scl_source enable llvm-toolset-7.0
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -20,9 +20,9 @@ if command -v apt; then
 elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
-    # yum -y install centos-release-scl llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
     yum -y install llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
-    # source scl_source enable llvm-toolset-7.0 || true
+    yum -y install centos-release-scl
+    source scl_source enable llvm-toolset-7.0 || true
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -20,8 +20,9 @@ if command -v apt; then
 elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
-    yum -y install centos-release-scl llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
-    source scl_source enable llvm-toolset-7.0 || true
+    # yum -y install centos-release-scl llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
+    yum -y install llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
+    # source scl_source enable llvm-toolset-7.0 || true
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -19,6 +19,10 @@ if command -v apt; then
     apt update && apt install --assume-yes libclang-7-dev clang-7 llvm-7
 elif command -v apk; then
     apk update && apk add clang-dev
+elif command -v yum; then
+    yum install centos-release-scl
+    yum install llvm-toolset-7.0
+    scl enable llvm-toolset-7.0 bash
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -21,8 +21,9 @@ elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
     yum -y install llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
-    yum -y install centos-release-scl
-    source scl_source enable llvm-toolset-7.0 || true
+    # (CentOS 7) Uncomment following lines to see required paths in build log:
+    #   yum -y install centos-release-scl
+    #   source scl_source enable llvm-toolset-7.0 || true
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -24,6 +24,8 @@ elif command -v yum; then
     source scl_source enable llvm-toolset-7.0 || true
     ln -s `which clang` /usr/local/bin/clang
     ln -s `which clang-7` /usr/local/bin/clang-7
+    ln -s `which llvm-config` /usr/local/bin/llvm-config
+    ln -s `which llvm-config-7` /usr/local/bin/llvm-config-7
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -22,8 +22,8 @@ elif command -v apk; then
 elif command -v yum; then
     yum -y install centos-release-scl llvm-toolset-7.0
     source scl_source enable llvm-toolset-7.0 || true
-    clang --version
-    clang-7 --version
+    ln -s `which clang` /usr/local/bin/clang
+    ln -s `which clang-7` /usr/local/bin/clang-7
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -22,10 +22,6 @@ elif command -v apk; then
 elif command -v yum; then
     yum -y install centos-release-scl llvm-toolset-7.0 llvm-toolset-7.0-llvm-devel
     source scl_source enable llvm-toolset-7.0 || true
-    ln -s `which clang` /usr/local/bin/clang
-    ln -s `which clang-7` /usr/local/bin/clang-7
-    ln -s `which llvm-config` /usr/local/bin/llvm-config
-    ln -s `which llvm-config-7` /usr/local/bin/llvm-config-7
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -22,6 +22,8 @@ elif command -v apk; then
 elif command -v yum; then
     yum -y install centos-release-scl llvm-toolset-7.0
     source scl_source enable llvm-toolset-7.0 || true
+    clang --version
+    clang-7 --version
 fi
 
 pushd rizin

--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -21,7 +21,7 @@ elif command -v apk; then
     apk update && apk add clang-dev
 elif command -v yum; then
     yum -y install centos-release-scl llvm-toolset-7.0
-    source scl_source enable llvm-toolset-7.0
+    source scl_source enable llvm-toolset-7.0 || true
 fi
 
 pushd rizin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,10 @@ manylinux-i686-image = "manylinux2014"
 skip = "pp*"
 
 [tool.cibuildwheel.linux]
-before-build = "source scl_source enable llvm-toolset-7.0 || true"
-environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/python/cp38-cp38/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH" }
+environment = {
+  PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/python/cp38-cp38/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH",
+  LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH",
+}
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_PREFIX_PATH="C:\\rizin" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,7 @@ manylinux-i686-image = "manylinux2014"
 skip = "pp*"
 
 [tool.cibuildwheel.linux]
-environment = {
-  PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/python/cp38-cp38/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH",
-  LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH",
-}
+environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/python/cp38-cp38/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH" }
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_PREFIX_PATH="C:\\rizin" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ manylinux-x86_64-image = "manylinux2014"
 skip = "pp*"
 
 [tool.cibuildwheel.linux]
-environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/rh/devtoolset-10/root/usr/bin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH" }
+environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:$LD_LIBRARY_PATH" }
 archs = ["x86_64"]
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ setup = ['-Dwheel=true']
 [tool.cibuildwheel]
 build-verbosity = 3
 before-all = "bash {project}/cibw_before_all.sh"
-before-build = "source scl_source enable llvm-toolset-7.0 || true"
+before-build-linux = "source scl_source enable llvm-toolset-7.0 || true"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 skip = "pp*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ setup = ['-Dwheel=true']
 build-verbosity = 3
 before-all = "bash {project}/cibw_before_all.sh"
 manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
 skip = "pp*"
 
 [tool.cibuildwheel.linux]
 environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/rh/devtoolset-10/root/usr/bin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH" }
+archs = ["x86_64"]
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_PREFIX_PATH="C:\\rizin" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ manylinux-i686-image = "manylinux2014"
 skip = "pp*"
 
 [tool.cibuildwheel.linux]
-environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/python/cp38-cp38/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH" }
+environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/rh/devtoolset-10/root/usr/bin:$PATH", LD_LIBRARY_PATH="/opt/rh/llvm-toolset-7.0/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib64:/opt/rh/devtoolset-10/root/usr/lib:/opt/rh/devtoolset-10/root/usr/lib64/dyninst:/opt/rh/devtoolset-10/root/usr/lib/dyninst:$LD_LIBRARY_PATH" }
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_PREFIX_PATH="C:\\rizin" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ skip = "pp*"
 
 [tool.cibuildwheel.linux]
 before-build = "source scl_source enable llvm-toolset-7.0 || true"
+environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset-7.0/root/usr/sbin:/opt/python/cp38-cp38/bin:/opt/rh/devtoolset-10/root/usr/bin:$PATH" }
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_PREFIX_PATH="C:\\rizin" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,12 @@ setup = ['-Dwheel=true']
 [tool.cibuildwheel]
 build-verbosity = 3
 before-all = "bash {project}/cibw_before_all.sh"
-before-build-linux = "source scl_source enable llvm-toolset-7.0 || true"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 skip = "pp*"
+
+[tool.cibuildwheel.linux]
+before-build = "source scl_source enable llvm-toolset-7.0 || true"
 
 [tool.cibuildwheel.windows]
 environment = { CMAKE_PREFIX_PATH="C:\\rizin" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ setup = ['-Dwheel=true']
 [tool.cibuildwheel]
 build-verbosity = 3
 before-all = "bash {project}/cibw_before_all.sh"
-manylinux-x86_64-image = "manylinux_2_24"
-manylinux-i686-image = "manylinux_2_24"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 skip = "pp*"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ setup = ['-Dwheel=true']
 [tool.cibuildwheel]
 build-verbosity = 3
 before-all = "bash {project}/cibw_before_all.sh"
+before-build = "source scl_source enable llvm-toolset-7.0 || true"
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"
 skip = "pp*"


### PR DESCRIPTION
This pr uses the `manylinux2014` base image instead of `manylinux_2_24` because the latter is [EOL](https://github.com/pypa/manylinux/issues/1332). The `manylinux_2_24` base image was chosen over `manylinux_2_28` because the latter [doesn't have an i686 image](https://github.com/pypa/manylinux#manylinux_2_28-almalinux-8-based).