### PR TITLE
Uniquify artifact names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: sdist
+        name: sdist-${{ matrix.os }}
         path: dist/*.tar.gz
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: wheelhouse/*.whl
 
   ubuntu-default-llvm:


### PR DESCRIPTION
As per [here](https://github.com/actions/upload-artifact#not-uploading-to-the-same-artifact), this pr makes sure artifact names are unique, and therefore all builds should be green on the first run.