### PR TITLE
Use `/` instead of `\\` in CMAKE_PREFIX_PATH for Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ environment = { PATH="/opt/rh/llvm-toolset-7.0/root/usr/bin:/opt/rh/llvm-toolset
 archs = ["x86_64"]
 
 [tool.cibuildwheel.windows]
-environment = { CMAKE_PREFIX_PATH="C:\\rizin" }
+environment = { CMAKE_PREFIX_PATH="C:/rizin" }
 archs = ["AMD64"]
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
This pr fixes the following problem (https://github.com/rizinorg/rz-bindgen/actions/runs/12432355334/job/34711579393#step:5:5217):

![rz-bindgen-lib-not-found](https://github.com/user-attachments/assets/a295c99e-d4e7-414c-9b10-df9f23221524)

by using `/` instead of `\\` in CMAKE_PREFIX_PATH.

Closes https://github.com/rizinorg/rz-bindgen/issues/70