### PR TITLE
ci: use corresponding rizin branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   workflow_call:
     inputs:
+      external_call:
+        description: 'To distinguish workflow_call from regular push'
+        type: boolean
+        required: false
+        default: true
       rizin_ref:
         required: false
         type: string
@@ -26,12 +31,30 @@ jobs:
     - name: Checkout rz-bindgen
       uses: actions/checkout@v4
 
+    # runned only from workflow_call
     - name: Checkout rizin
+      if: ${{ inputs.external_call }}
       uses: actions/checkout@v4
       with:
         repository: rizinorg/rizin
         path: rizin
         ref: ${{ inputs.rizin_ref }}
+
+    - name: Checkout rizin (stable)
+      if: ${{ !inputs.external_call && ((github.ref_name == 'stable') || (github.base_ref == 'stable')) }}
+      uses: actions/checkout@v4
+      with:
+        repository: rizinorg/rizin
+        path: rizin
+        ref: stable
+
+    - name: Checkout rizin (dev)
+      if: ${{ !inputs.external_call && ((github.ref_name != 'stable') && (github.base_ref != 'stable')) }}
+      uses: actions/checkout@v4
+      with:
+        repository: rizinorg/rizin
+        path: rizin
+        ref: dev
 
     - name: Build rz-bindgen
       uses: pypa/cibuildwheel@v2.22.0


### PR DESCRIPTION
To run on Rizin `dev` when called from `dev` branch or pull requests not targeting `stable`, and run on `stable` if called from `stable` branch or a pull request to it.