### PR TITLE
Cleanup inclusion of linux/limits.h

### DIFF
--- a/cibw_before_all.sh
+++ b/cibw_before_all.sh
@@ -38,10 +38,10 @@ pushd rizin
 if [[ "$OSTYPE" =~ msys* ]]; then
     meson setup --buildtype=release --prefix='c:/rizin' --vsenv build
     meson install -C build
-elif [[ "$OSTYPE" =~ linux* ]]; then
-    CFLAGS="-include linux/limits.h" meson setup --buildtype=release --libdir=lib build
-    sudo meson install -C build
 else
+    if [[ "$OSTYPE" =~ linux* ]]; then
+        export CFLAGS="-include linux/limits.h"
+    fi
     meson setup --buildtype=release --libdir=lib build
     sudo meson install -C build
 fi


### PR DESCRIPTION
This pr just cleans up the inclusion of `linux/limits.h` to reduce redundancy.