### PR TITLE
Suppress pylint's invalid-name warning

### DIFF
--- a/src/cparser_header.py
+++ b/src/cparser_header.py
@@ -76,7 +76,7 @@ class CFunc(AttrCursor):
 
 
 ### Configuration ###
-rizin_include_path: Optional[str] = None
+rizin_include_path: Optional[str] = None  # pylint: disable=invalid-name
 clang_args: List[str] = []
 
 ### Headers ###

--- a/src/generator_sphinx.py
+++ b/src/generator_sphinx.py
@@ -39,7 +39,7 @@ from binding_func import Func
 
 from writer import Writer
 
-doxygen_path: Optional[str] = None
+doxygen_path: Optional[str] = None  # pylint: disable=invalid-name
 
 DoxygenElements = Dict[str, Element]
 


### PR DESCRIPTION
In the absence of proper tests, this pr resolves pylint's `invalid-name` warning the easy way by suppressing it.