### PR TITLE
Rename rz_list_iter_get_next to rz_list_get_next

### DIFF
--- a/src/bindings.py
+++ b/src/bindings.py
@@ -63,7 +63,7 @@ def bind_list(list_h: Header) -> None:
     """
     ### RzListIter ###
     rz_list_iter = Generic(list_h, "RzListIter", pointer=True)
-    rz_list_iter.add_method("rz_list_iter_get_next", rename="next", generic_ret=True)
+    rz_list_iter.add_method("rz_list_get_next", rename="next", generic_ret=True)
     rz_list_iter.add_method("rz_list_iter_get_data", rename="data", generic_ret=True)
 
     ### RzList ###


### PR DESCRIPTION
This pr renames `rz_list_iter_get_next` to `rz_list_get_next` due to rizinorg/rizin#5696 and rizinorg/rizin#5718.