### PR TITLE
Run CI on non-rizinorg pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: build
 on:
   push:
+  pull_request:
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: lint
-on: push
+on:
+  push:
+  pull_request:
 jobs:
   licenses:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This pr makes it such that the CI (including linters) will run on non-rizinorg pull requests.