### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -34,3 +34,7 @@ License: LGPL-3.0-only
 Files: tests/*
 Copyright: 2026 RizinOrg <info@rizin.re>
 License: LGPL-3.0-only
+
+Files: .github/**
+Copyright: 2026 RizinOrg <info@rizin.re>
+License: LGPL-3.0-only


### PR DESCRIPTION
This pr adds to the repo [Dependabot](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) for GitHub Actions.