### PR TITLE
Add `src/snippets_swig/` files to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,11 @@ if target_swig or target_sphinx
     'src/lint.py',
     'src/main.py',
     'src/writer.py',
+    'src/snippets_swig/cmd_director.i',
+    'src/snippets_swig/iterators.py',
+    'src/snippets_swig/prologue.i',
+    'src/snippets_swig/register_command.py',
+    'src/snippets_swig/register_swig_command.cpp',
   )
 
   bindgen_outputs = custom_target(


### PR DESCRIPTION
This pr adds the `src/snippets_swig/` files to meson.build since they are used by `src/generator_swig.py`.