### PR TITLE
Show deprecated warning on stderr instead

### DIFF
--- a/src/snippets_swig/prologue.i
+++ b/src/snippets_swig/prologue.i
@@ -9,11 +9,12 @@ bool rizin_warn_deprecate_instructions = true;
 %{
 void rizin_try_warn_deprecate(const char *name, const char *c_name) {
     if (rizin_warn_deprecate) {
-        printf("Warning: `%s` calls deprecated function `%s`\n", name, c_name);
+        fprintf(stderr, "Warning: `%s` calls deprecated function `%s`\n", name, c_name);
         if (rizin_warn_deprecate_instructions) {
-            puts("To disable this warning, set rizin_warn_deprecate to false");
-            puts("The way to do this depends on the SWIG language being used");
-            puts("For python, do `rizin.cvar.rizin_warn_deprecate = False`");
+            fprintf(stderr,
+                "To disable this warning, set rizin_warn_deprecate to false\n"
+                "The way to do this depends on the SWIG language being used\n"
+                "For python, do `rizin.cvar.rizin_warn_deprecate = False`\n");
         }
     }
 }

--- a/tests/examples
+++ b/tests/examples
@@ -2,16 +2,18 @@ NAME=1-rz_core.py =
 FILE=--
 CMDS=<<EOF
 !echo 'q!!' | python3 examples/1-rz_core.py =
+echo
 EOF
 EXPECT=<<EOF
 Loaded 1 file(s)
 Corefile #1 has 1 binfile(s)
  * malloc://512
-rizin> Warning: `next` calls deprecated function `rz_list_get_next`
+rizin> 
+EOF
+EXPECT_ERR=<<EOF
+Warning: `next` calls deprecated function `rz_list_get_next`
 To disable this warning, set rizin_warn_deprecate to false
 The way to do this depends on the SWIG language being used
 For python, do `rizin.cvar.rizin_warn_deprecate = False`
-EOF
-EXPECT_ERR=<<EOF
 EOF
 RUN


### PR DESCRIPTION
This pr makes the SWIG code show the deprecated warning on stderr instead of stdout, since warnings should be on stderr.