### PR TITLE
Remove `-C .` from CI rz-test invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,5 +129,5 @@ jobs:
       run: rizin -qc "Ll" | grep "Python SWIG"
 
     - name: Run rz-test
-      run: rz-test -C . -L tests/
+      run: rz-test -L tests/
       working-directory: rz-bindgen


### PR DESCRIPTION
This pr removes `-C .` from the following rz-test invocation:
https://github.com/rizinorg/rz-bindgen/blob/d8565432535fde76e28a66b537671fa30d48fc85/.github/workflows/ci.yml#L132 since it is no longer needed after rizinorg/rizin#5852.