### PR TITLE
examples: Allow `q` to exit prompt loop

### DIFF
--- a/doc/core.md
+++ b/doc/core.md
@@ -66,8 +66,8 @@ for i, corefile in enumerate(core.files):
     for binfile in corefile.binfiles:
         print(f" * {binfile.file}")
 
-while True:
-    core.flush(input("rizin> "))
+while core.flush(input("rizin> ")) != -2:
+    pass
 ```
 
 Here's an example session:

--- a/examples/1-rz_core.py
+++ b/examples/1-rz_core.py
@@ -20,5 +20,5 @@ for i, corefile in enumerate(core.files):
     for binfile in corefile.binfiles:
         print(f" * {binfile.file}")
 
-while True:
-    core.flush(input("rizin> "))
+while core.flush(input("rizin> ")) != -2:
+    pass

--- a/examples/2a-rz_bin_plugin.py
+++ b/examples/2a-rz_bin_plugin.py
@@ -36,5 +36,5 @@ core.bin.plugins.append(plugin)
 core.bin.force_plugin(plugin.name)
 core.file_open_load(sys.argv[1])
 
-while True:
-    core.flush(input("> "))
+while core.flush(input("rizin> ")) != -2:
+    pass

--- a/examples/2b-rz_bin_plugin.py
+++ b/examples/2b-rz_bin_plugin.py
@@ -26,5 +26,5 @@ core.bin.plugins.append(plugin_struct)
 core.bin.force_plugin(plugin.name)
 core.file_open_load(sys.argv[1])
 
-while True:
-    core.flush(input("> "))
+while core.flush(input("rizin> ")) != -2:
+    pass

--- a/tests/examples
+++ b/tests/examples
@@ -1,7 +1,7 @@
 NAME=1-rz_core.py =
 FILE=--
 CMDS=<<EOF
-!echo 'q!!' | python3 examples/1-rz_core.py =
+!echo q | python3 examples/1-rz_core.py =
 echo
 EOF
 EXPECT=<<EOF


### PR DESCRIPTION
This pr modifies the examples so that `q` can be used to exit the `rizin> ` prompt loop.