### PR TITLE
Add bindings for `RZ_CORE_CMD_` constants

### DIFF
--- a/doc/core.md
+++ b/doc/core.md
@@ -50,6 +50,7 @@ In the SWIG bindings, these functions are mapped to methods of RzCore.
 
 ```py
 import rizin
+from rizin import RZ_CORE_CMD_EXIT as CMD_EXIT
 from sys import argv
 
 filename = argv[1]
@@ -66,7 +67,7 @@ for i, corefile in enumerate(core.files):
     for binfile in corefile.binfiles:
         print(f" * {binfile.file}")
 
-while core.flush(input("rizin> ")) != -2:
+while core.flush(input("rizin> ")) != CMD_EXIT:
     pass
 ```
 
@@ -86,10 +87,11 @@ rizin> aaa
 [x] Applied 0 FLIRT signatures via sigdb
 [x] Propagate noreturn information
 [x] Use -AA or aaaa to perform additional experimental analysis.
-> afl
+rizin> afl
 0x0040233e    1 6            entry0
 0x00402051    3 49   -> 16   sym.HelloWorld::Main
 0x0040205f   99 24482 -> 31854 sym.HelloWorld::.ctor
+rizin> q
 ```
 
 ### Plugins

--- a/examples/1-rz_core.py
+++ b/examples/1-rz_core.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: LGPL-3.0-only
 """
 
 import rizin
+from rizin import RZ_CORE_CMD_EXIT as CMD_EXIT
 from sys import argv
 
 filename = argv[1]
@@ -20,5 +21,5 @@ for i, corefile in enumerate(core.files):
     for binfile in corefile.binfiles:
         print(f" * {binfile.file}")
 
-while core.flush(input("rizin> ")) != -2:
+while core.flush(input("rizin> ")) != CMD_EXIT:
     pass

--- a/examples/2a-rz_bin_plugin.py
+++ b/examples/2a-rz_bin_plugin.py
@@ -8,10 +8,9 @@ SPDX-License-Identifier: LGPL-3.0-only
 # things, see `2b-rz_bin_plugin.py`
 
 import rizin
+from rizin import RZ_CORE_CMD_EXIT as CMD_EXIT
 import sys
 
-
-import rizin
 
 class CustomBinPlugin(rizin.RzBinPluginDirector):
     def __init__(self):
@@ -22,6 +21,7 @@ class CustomBinPlugin(rizin.RzBinPluginDirector):
         print("name: ", bf.file)
         print("size: ", bf.size)
         return True
+
 
 # Construct the director
 builder = rizin.RzBinPluginBuilder()
@@ -36,5 +36,5 @@ core.bin.plugins.append(plugin)
 core.bin.force_plugin(plugin.name)
 core.file_open_load(sys.argv[1])
 
-while core.flush(input("rizin> ")) != -2:
+while core.flush(input("rizin> ")) != CMD_EXIT:
     pass

--- a/examples/2b-rz_bin_plugin.py
+++ b/examples/2b-rz_bin_plugin.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: LGPL-3.0-only
 """
 
 import rizin
+from rizin import RZ_CORE_CMD_EXIT as CMD_EXIT
 import sys
 
 
@@ -26,5 +27,5 @@ core.bin.plugins.append(plugin_struct)
 core.bin.force_plugin(plugin.name)
 core.file_open_load(sys.argv[1])
 
-while core.flush(input("rizin> ")) != -2:
+while core.flush(input("rizin> ")) != CMD_EXIT:
     pass

--- a/src/bindings.py
+++ b/src/bindings.py
@@ -327,6 +327,8 @@ def bind_core(core_h: Header) -> None:
 
     Class(core_h, typedef="RzCoreFile")
 
+    MacroEnum(core_h, prefix="RZ_CORE_CMD_")
+
 
 @threaded_header("rz_flag.h")
 def bind_flag(flag_h: Header) -> None:


### PR DESCRIPTION
This pr adds bindings for `RZ_CORE_CMD_` constants so that they can be used in scripts.