### PR TITLE
RzListIter.next: Use rz_list_next() macro instead

### DIFF
--- a/src/binding_generic.py
+++ b/src/binding_generic.py
@@ -29,6 +29,7 @@ class Generic:
 
     specializations: Set[str]
 
+    c_methods: OrderedDict[str, List[str]]
     python_methods: OrderedDict[str, List[str]]
     specialization_extensions: DefaultDict[str, List[str]]
 
@@ -49,6 +50,7 @@ class Generic:
         self.methods = OrderedDict()
         self.specializations = set()
 
+        self.c_methods = OrderedDict()
         self.python_methods = OrderedDict()
         self.specialization_extensions = DefaultDict(list)
 
@@ -131,9 +133,15 @@ class Generic:
 
         return specialization
 
+    def add_c_method(self, name: str, *lines: str) -> None:
+        """
+        Add C method for name
+        """
+        self.c_methods[name] = list(lines)
+
     def add_python_method(self, decl: str, *lines: str) -> None:
         """
-        Add python function with decl
+        Add python method with decl
         """
         self.python_methods[decl] = [f"def {decl}:"] + [f"    {line}" for line in lines]
 

--- a/src/bindings.py
+++ b/src/bindings.py
@@ -63,7 +63,12 @@ def bind_list(list_h: Header) -> None:
     """
     ### RzListIter ###
     rz_list_iter = Generic(list_h, "RzListIter", pointer=True)
-    rz_list_iter.add_method("rz_list_get_next", rename="next", generic_ret=True)
+    rz_list_iter.add_c_method(
+        "rz_list_next",
+        "RzListIter_##TYPE *next() {",
+        "    return (RzListIter_##TYPE *)rz_list_next($self);",
+        "}",
+    )
     rz_list_iter.add_method("rz_list_iter_get_data", rename="data", generic_ret=True)
 
     ### RzList ###

--- a/src/generator_swig.py
+++ b/src/generator_swig.py
@@ -114,6 +114,9 @@ def write_generic(writer: Writer, generic: Generic) -> None:
             for name, method in generic.methods.items():
                 write_func(writer, method, name, FuncKind.GENERIC)
 
+            for c_lines in generic.c_methods.values():
+                writer.line(*c_lines)
+
             for python_lines in generic.python_methods.values():
                 writer.line("%pythoncode %{")
                 with writer.indent():

--- a/tests/examples
+++ b/tests/examples
@@ -11,9 +11,5 @@ Corefile #1 has 1 binfile(s)
 rizin> 
 EOF
 EXPECT_ERR=<<EOF
-Warning: `next` calls deprecated function `rz_list_get_next`
-To disable this warning, set rizin_warn_deprecate to false
-The way to do this depends on the SWIG language being used
-For python, do `rizin.cvar.rizin_warn_deprecate = False`
 EOF
 RUN


### PR DESCRIPTION
This pr makes `RzListIter.next()` use the `rz_list_next()` macro instead, since the `rz_list_get_next()` function has been declared as deprecated.