### PR TITLE
Update CI to `windows-2022`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2019, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-14]
 
     steps:
     - name: Install SWIG with Homebrew


### PR DESCRIPTION
This pr updates the CI Windows image to `windows-2022` since the currently used `windows-2019` image [has been deprecated](https://github.com/actions/runner-images/issues/12045) for a long time and apparently is no longer available.