### PR TITLE
Support typedef of typedef of a function pointer

### DIFF
--- a/src/binding_generic_specializations.py
+++ b/src/binding_generic_specializations.py
@@ -42,10 +42,15 @@ def gen_ctype_specializations(cursors: List[Cursor], ctype: CType) -> None:
             # eg. typedef RzVector /*<ut64>*/ (*func)(void)
             gen_ctype_specializations(cursors + [ctype.cursor], ctype.canonical)
     elif isinstance(ctype, CFunctionType):
+        cursor_children = [cursor for cursor in cursors[-1].get_children()]
+        # Handle typedef of typedef of a function pointer
+        while len(cursor_children) == 1 and cursor_children[0].kind == CursorKind.TYPE_REF:
+            cursor_children = [cursor for cursor in cursor_children[0].referenced.get_children()]
+
         gen_ctype_specializations(cursors, ctype.result)
         cursor_args = [
             cursor
-            for cursor in cursors[-1].get_children()
+            for cursor in cursor_children
             if cursor.kind == CursorKind.PARM_DECL
         ]
 

--- a/src/binding_generic_specializations.py
+++ b/src/binding_generic_specializations.py
@@ -42,10 +42,11 @@ def gen_ctype_specializations(cursors: List[Cursor], ctype: CType) -> None:
             # eg. typedef RzVector /*<ut64>*/ (*func)(void)
             gen_ctype_specializations(cursors + [ctype.cursor], ctype.canonical)
     elif isinstance(ctype, CFunctionType):
-        cursor_children = [cursor for cursor in cursors[-1].get_children()]
+        cursor_children = list(cursors[-1].get_children())
         # Handle typedef of typedef of a function pointer
         while len(cursor_children) == 1 and cursor_children[0].kind == CursorKind.TYPE_REF:
-            cursor_children = [cursor for cursor in cursor_children[0].referenced.get_children()]  # type: ignore[attr-defined]
+            cursor_children = \
+                list(cursor_children[0].referenced.get_children())  # type: ignore[attr-defined]
 
         gen_ctype_specializations(cursors, ctype.result)
         cursor_args = [

--- a/src/binding_generic_specializations.py
+++ b/src/binding_generic_specializations.py
@@ -45,7 +45,7 @@ def gen_ctype_specializations(cursors: List[Cursor], ctype: CType) -> None:
         cursor_children = [cursor for cursor in cursors[-1].get_children()]
         # Handle typedef of typedef of a function pointer
         while len(cursor_children) == 1 and cursor_children[0].kind == CursorKind.TYPE_REF:
-            cursor_children = [cursor for cursor in cursor_children[0].referenced.get_children()]
+            cursor_children = [cursor for cursor in cursor_children[0].referenced.get_children()]  # type: ignore[attr-defined]
 
         gen_ctype_specializations(cursors, ctype.result)
         cursor_args = [

--- a/src/binding_generic_specializations.py
+++ b/src/binding_generic_specializations.py
@@ -44,15 +44,16 @@ def gen_ctype_specializations(cursors: List[Cursor], ctype: CType) -> None:
     elif isinstance(ctype, CFunctionType):
         cursor_children = list(cursors[-1].get_children())
         # Handle typedef of typedef of a function pointer
-        while len(cursor_children) == 1 and cursor_children[0].kind == CursorKind.TYPE_REF:
-            cursor_children = \
-                list(cursor_children[0].referenced.get_children())  # type: ignore[attr-defined]
+        while (
+            len(cursor_children) == 1 and cursor_children[0].kind == CursorKind.TYPE_REF
+        ):
+            cursor_children = list(
+                cursor_children[0].referenced.get_children()  # type: ignore[attr-defined]
+            )
 
         gen_ctype_specializations(cursors, ctype.result)
         cursor_args = [
-            cursor
-            for cursor in cursor_children
-            if cursor.kind == CursorKind.PARM_DECL
+            cursor for cursor in cursor_children if cursor.kind == CursorKind.PARM_DECL
         ]
 
         assert len(cursor_args) == len(ctype.args)

--- a/src/binding_generic_specializations.py
+++ b/src/binding_generic_specializations.py
@@ -43,6 +43,7 @@ def gen_ctype_specializations(cursors: List[Cursor], ctype: CType) -> None:
             gen_ctype_specializations(cursors + [ctype.cursor], ctype.canonical)
     elif isinstance(ctype, CFunctionType):
         cursor_children = list(cursors[-1].get_children())
+
         # Handle typedef of typedef of a function pointer
         while (
             len(cursor_children) == 1 and cursor_children[0].kind == CursorKind.TYPE_REF


### PR DESCRIPTION
This pr adds support for typedef of typedef of a function pointer e.g. `SdbForeachCallback` below:

```c
typedef bool (*SdbHtForeachCallback)(void *user, const SdbKv *kv);
...
typedef SdbHtForeachCallback SdbForeachCallback;
```
(https://github.com/rizinorg/rizin/blob/d6f278e1a5dc55358916fb7f326c8ffdebf81a29/librz/util/sdb/src/sdbht.h#L19 ... https://github.com/rizinorg/rizin/blob/d6f278e1a5dc55358916fb7f326c8ffdebf81a29/librz/util/sdb/src/sdb.h#L112)

and fixes the builds (except the Windows build, but that's a different issue).