### PR TITLE
Add `branches` filter to `on: push:` CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: build
 on:
   push:
+    branches:
+      - dev
+      - stable
+      - 'ci-*'
   pull_request:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: lint
 on:
   push:
+    branches:
+      - dev
+      - stable
+      - 'ci-*'
   pull_request:
 jobs:
   licenses:


### PR DESCRIPTION
This pr adds a `branches` filter to the `on: push:` CI so that a rizinorg pr doesn't run the CI twice.