### PR TITLE
Support stdint.h definitions

### DIFF
--- a/src/snippets_swig/prologue.i
+++ b/src/snippets_swig/prologue.i
@@ -20,6 +20,9 @@ void rizin_try_warn_deprecate(const char *name, const char *c_name) {
 }
 %}
 
+// uint64_t, int64_t etc
+%include <stdint.i>
+
 // Buffer typemaps
 %include <pybuffer.i>
 %pybuffer_mutable_binary(unsigned char *buf, unsigned long long len);


### PR DESCRIPTION
This pr fixes the following error:

<img width="932" height="320" alt="uint64_t error" src="https://github.com/user-attachments/assets/9e0b4f08-cf86-457d-98c5-a7ed18462652" />

(https://github.com/rizinorg/rz-bindgen/actions/runs/25169427459/job/73784379169?pr=115#step:10:28)

by %including SWIG's stdint support.